### PR TITLE
Allow stable Rust 1.35.0 and newer to compile

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-#![feature(range_contains)]
-
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;


### PR DESCRIPTION
Problem

The attribute `#![feature(range_contains)]` prevented us from compiling this great crate on the stable release channel.

Solution

Simply remove the above mentioned attribute because the feature `range_contains` has already been stable since Rust 1.35.0.
