### PR TITLE
Fix build warnings from the CI Linux build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,17 @@ test:linux --test_tag_filters=-macos_only
 # line to opt in.
 common --repo_env=DO_NOT_TRACK=1
 
+# Don't synthesize __init__.py files into Python runfiles. rules_python warns
+# that this legacy behavior is deprecated; nothing here imports a package that
+# needs it. Setting it globally (rather than legacy_create_init = 0 per target)
+# also covers external py targets such as @bazel_tools//tools/jdk targets.
+#
+# Both flags are needed: rules_python reads the native Bazel flag when
+# ctx.fragments.py exists and its own Starlark flag when it doesn't, and which
+# path is taken depends on the Bazel version.
+build --incompatible_default_to_explicit_init_py
+build --@rules_python//python/config_settings:incompatible_default_to_explicit_init_py=true
+
 # Set Ruby build environment for rules_ruby
 # These environment variables are used by ruby-build during Ruby compilation
 build --action_env=RUBY_CONFIGURE_OPTS="--disable-install-doc"

--- a/rust/python-bindings/src/autolinker.rs
+++ b/rust/python-bindings/src/autolinker.rs
@@ -242,7 +242,7 @@ impl Autolinker {
 }
 
 impl Autolinker {
-    fn to_rust_autolinker(&self) -> RustAutolinker {
+    fn to_rust_autolinker(&self) -> RustAutolinker<'_> {
         let mut extractor = Extractor::new();
         extractor.set_extract_url_without_protocol(false);
 

--- a/rust/swift-bindings/BUILD.bazel
+++ b/rust/swift-bindings/BUILD.bazel
@@ -63,6 +63,9 @@ swift_binary(
     ],
     # LD_LIBRARY_PATH is set dynamically by run_tests.sh at runtime
     linkopts = [
+        # rules_swift's Linux toolchain unconditionally adds -static-libgcc,
+        # which the clang driver reports as unused when it only links.
+        "-Wno-unused-command-line-argument",
         "-lswiftCore",
         "-lswiftSwiftOnoneSupport",
         "-lFoundation",

--- a/rust/twitter-text/BUILD.bazel
+++ b/rust/twitter-text/BUILD.bazel
@@ -75,6 +75,17 @@ twitter_text_wasm_srcs = [
     "src/validator.rs",
 ]
 
+# simd128 only exists on wasm targets. The wasm rules transition their deps to
+# @rules_rust//rust/platform:wasm32, but plain `bazel build` of these targets
+# compiles them for the host, where rustc warns that the feature is unknown.
+WASM_SIMD_FLAGS = select({
+    "@platforms//cpu:wasm32": [
+        "-C",
+        "target-feature=+simd128",
+    ],
+    "//conditions:default": [],
+})
+
 # 1) Core Rust crate, no cxx in the public API
 rust_library(
     name = "twitter_text_rlib",
@@ -93,7 +104,7 @@ rust_library(
     srcs = twitter_text_wasm_srcs,
     deps = twitter_text_wasm_deps,
     edition = "2021",
-    rustc_flags = ["-C", "target-feature=+simd128"],
+    rustc_flags = WASM_SIMD_FLAGS,
 )
 
 # 2) Static library with FFI, built from the same sources but with ffi feature

--- a/rust/wasm-bindings/BUILD.bazel
+++ b/rust/wasm-bindings/BUILD.bazel
@@ -4,13 +4,25 @@ load("@rules_rust_wasm_bindgen//:defs.bzl", "rust_wasm_bindgen")
 
 package(default_visibility = ["//visibility:public"])
 
+# simd128 only exists on wasm targets. rust_wasm_bindgen transitions this
+# library to @rules_rust//rust/platform:wasm32, but building it directly (e.g.
+# `bazel build //rust/wasm-bindings/...`) compiles it for the host, where rustc
+# warns that the feature is unknown.
+WASM_SIMD_FLAGS = select({
+    "@platforms//cpu:wasm32": [
+        "-C",
+        "target-feature=+simd128",
+    ],
+    "//conditions:default": [],
+})
+
 # Build Rust library targeting WASM
 rust_shared_library(
     name = "twitter_text_wasm_lib",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
     edition = "2021",
-    rustc_flags = ["-C", "target-feature=+simd128"],
+    rustc_flags = WASM_SIMD_FLAGS,
     deps = [
         "//rust/twitter-text:twitter_text_wasm_rlib",
         "//rust/config:twitter_text_config",


### PR DESCRIPTION
Clears the four sources of diagnostic noise in the `--config=ci-linux` build.

- **`+simd128` unknown feature (44 lines/build)** — the flag was unconditional on `//rust/twitter-text:twitter_text_wasm_rlib` and `//rust/wasm-bindings:twitter_text_wasm_lib`. `rust_wasm_bindgen` transitions its `wasm_file` dep to `@rules_rust//rust/platform:wasm32`, but building those targets directly (which `//rust/wasm-bindings/...` does) compiles them for the host, where the feature doesn't exist. Now behind a `select()` on `@platforms//cpu:wasm32`. Checked with aquery: the wasm-transitioned actions still carry `+simd128`, the host ones don't.
- **`mismatched_lifetime_syntaxes`** — `to_rust_autolinker(&self) -> RustAutolinker<'_>`, matching what the wasm binding already does.
- **rules_python implicit `__init__.py` (10 targets)** — set globally, since one warning comes from `@bazel_tools//tools/jdk:proguard_allowlister`. Both the native and the rules_python Starlark flag are set: `read_possibly_native_flag` picks between them based on whether `ctx.fragments.py` exists, which varies by Bazel version. Reproduced locally by forcing the Starlark flag off, then confirmed no warning and no synthesized `__init__.py` in runfiles with the TLD generators still running.
- **`-static-libgcc` unused during compilation** — comes from rules_swift's own Linux toolchain linkopts, so suppressed with `-Wno-unused-command-line-argument` on `SwiftTestRunner`.

Not verified locally: the Rust compile, Python tests, and Swift link. Every local Rust build on this machine fails in an external crate (`E0463: can't find crate for thiserror_impl`) from the Xcode-beta proc-macro issue, unrelated to this change — hence relying on CI here.

Left alone: `There were tests whose specified size is too big`. No test declares `size`, so all default to `medium` while running in ~1s; fixing it means annotating targets and tightening timeouts to 60s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)